### PR TITLE
fix: guard scroll indicator behavior

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -63,8 +63,16 @@ const animateOnScroll = () => {
     smoothScroll();
   });
 
-  document.querySelector('.scroll-indicator').addEventListener('click', function() {
-        document.querySelector('.calendly-inline-widget').scrollIntoView({
+  document.addEventListener('DOMContentLoaded', () => {
+    const scrollIndicator = document.querySelector('.scroll-indicator');
+    if (scrollIndicator) {
+      scrollIndicator.addEventListener('click', () => {
+        const calendlyWidget = document.querySelector('.calendly-inline-widget');
+        if (calendlyWidget) {
+          calendlyWidget.scrollIntoView({
             behavior: 'smooth'
-        });
-    });
+          });
+        }
+      });
+    }
+  });

--- a/js/service.js
+++ b/js/service.js
@@ -366,10 +366,17 @@ document.addEventListener('DOMContentLoaded', function() {
     //     }
     // });
     
-    // Scroll to services when clicking indicator
-    document.querySelector('.scroll-indicator').addEventListener('click', function() {
-        document.querySelector('.interactive-services').scrollIntoView({
-            behavior: 'smooth'
+// Scroll to services when clicking indicator
+document.addEventListener('DOMContentLoaded', function() {
+    const scrollIndicator = document.querySelector('.scroll-indicator');
+    if (scrollIndicator) {
+        scrollIndicator.addEventListener('click', function() {
+            const servicesSection = document.querySelector('.interactive-services');
+            if (servicesSection) {
+                servicesSection.scrollIntoView({
+                    behavior: 'smooth'
+                });
+            }
         });
-    });
+    }
 });


### PR DESCRIPTION
## Summary
- Prevent errors when scroll indicator or target widgets are missing in global script
- Initialize scroll indicator on services page after DOM load and guard missing sections

## Testing
- `npm test` *(fails: no such file or directory, open '/workspace/Haykal.sa/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c667e77ea88323b9dcef45a1e85fdf